### PR TITLE
相手のコマを飛び越えるはずが、重なってしまうバグを修正

### DIFF
--- a/src/quoridor/piece.test.ts
+++ b/src/quoridor/piece.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { GameManager } from "./game-manager";
+import { Piece } from "./piece";
+
+test("new Piece", () => {
+  const player = new Piece(1, 2);
+  expect(player.X).toBe(1);
+  expect(player.Y).toBe(2);
+});
+
+test("showSelectableTiles", () => {
+  const stage = GameManager.singleton;
+  const white = new Piece(4, 4);
+  const black = new Piece(4, 5);
+  stage.players = [white, black];
+  black.showSelectableTiles();
+  expect(stage.selectableTilesContainer.children.length).toBe(4);
+  expect(stage.selectableTilesContainer.children[0]).toContain({ X: 4, Y: 3 });
+  expect(stage.selectableTilesContainer.children[1]).toContain({ X: 4, Y: 6 });
+  expect(stage.selectableTilesContainer.children[2]).toContain({ X: 3, Y: 5 });
+  expect(stage.selectableTilesContainer.children[3]).toContain({ X: 5, Y: 5 });
+});

--- a/src/quoridor/piece.ts
+++ b/src/quoridor/piece.ts
@@ -34,7 +34,8 @@ export class Piece extends Sprite {
     if (pIndex === -1) {
       throw new Error("player not found");
     }
-    const selectables = getSelectables(stage, this);
+    const enemy = stage.players[1 - pIndex];
+    const selectables = getSelectables(stage, this, enemy);
 
     for (const { X, Y } of selectables) {
       const tile = new SelectableTile(X, Y);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 駒クラスに敵プレイヤーを参照するロジックを追加し、選択可能なタイルの取得時に影響します。

- **テスト**
	- 駒クラスとそのメソッドのテストを追加。新しい駒のインスタンス化と選択可能なタイルの表示を含みます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->